### PR TITLE
Fix listener and solicitation destination address

### DIFF
--- a/inet.c
+++ b/inet.c
@@ -29,6 +29,7 @@
 
 #include "inet.h"
 
+#define MC_ALL_ROUTERS       "224.0.0.2"
 #define MC_ALL_SNOOPERS      "224.0.0.106"
 
 
@@ -57,10 +58,10 @@ int inet_open(char *ifname)
 	}
 
 	memset(&mreq, 0, sizeof(mreq));
-	mreq.imr_multiaddr.s_addr = inet_addr(MC_ALL_SNOOPERS);
+	mreq.imr_multiaddr.s_addr = inet_addr(MC_ALL_ROUTERS);
 	mreq.imr_ifindex = if_nametoindex(ifname);
         if (setsockopt(sd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)))
-		err(1, "Failed joining group %s", MC_ALL_SNOOPERS);
+		err(1, "Failed joining group %s", MC_ALL_ROUTERS);
 
 	val = 1;
 	rc = setsockopt(sd, IPPROTO_IP, IP_MULTICAST_TTL, &val, sizeof(val));

--- a/solicit.c
+++ b/solicit.c
@@ -26,7 +26,7 @@
 #include <netinet/igmp.h>
 #include <sys/socket.h>
 
-#define MC_ALL_SNOOPERS      "224.0.0.106"
+#define MC_ALL_ROUTERS       "224.0.0.2"
 #define IGMP_MRDISC_ANNOUNCE 0x30
 #define IGMP_MRDISC_SOLICIT  0x31
 #define IGMP_MRDISC_TERM     0x32
@@ -84,7 +84,7 @@ static int send_message(int sd, uint8_t type, uint8_t interval)
 	igmp.igmp_code = interval;
 	igmp.igmp_cksum = 0;
 
-	compose_addr((struct sockaddr_in *)&dest, MC_ALL_SNOOPERS);
+	compose_addr((struct sockaddr_in *)&dest, MC_ALL_ROUTERS);
 
 	num = sendto(sd, &igmp, sizeof(igmp), 0, &dest, sizeof(dest));
 	if (num < 0)


### PR DESCRIPTION
RFC4286, section 4.2.2 states that the IP destination address for
MRD solicitation messages has to be the All-Routers multicast address
and not the All-Snoopers one. Fixing this both on the receiver (mrdisc)
and transmitter (solicit) side:

The latter needs to transmit to the All-Routers multicast
address and the former needs to join and listen to it.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>