### PR TITLE
Add IPv6 support to mrdisc and solicit

### DIFF
--- a/common.c
+++ b/common.c
@@ -16,8 +16,10 @@
  */
 
 #include <arpa/inet.h>
+#include <err.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 uint16_t in_cksum(uint16_t *p, size_t len)
 {
@@ -30,6 +32,15 @@ uint16_t in_cksum(uint16_t *p, size_t len)
 	sum = (sum % 0x10000) + (sum / 0x10000);
 
 	return htons(((uint16_t)sum) ^ 0xffff);
+}
+
+void compose_addr6(struct sockaddr_in6 *sin, char *group)
+{
+	memset(sin, 0, sizeof(*sin));
+	sin->sin6_family = AF_INET6;
+
+	if (!inet_pton(AF_INET6, group, &sin->sin6_addr))
+		err(1, "Failed preparing %s", group);
 }
 
 /**

--- a/if.c
+++ b/if.c
@@ -20,15 +20,18 @@
 #include <poll.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <sys/socket.h>
 #include <time.h>
 
 #include "if.h"
 #include "inet.h"
 
-size_t   ifnum = 0;
-ifsock_t iflist[MAX_NUM_IFACES];
+size_t   ifnum4 = 0;
+size_t   ifnum6 = 0;
+ifsock_t iflist4[MAX_NUM_IFACES];
+ifsock_t iflist6[MAX_NUM_IFACES];
 
-void if_init(char *iface[], int num)
+void if_init4(char *iface[], int num)
 {
 	int i, sd;
 	char *ifname;
@@ -40,9 +43,29 @@ void if_init(char *iface[], int num)
 		if (sd < 0)
 			continue;
 
-		iflist[ifnum].sd = sd;
-		iflist[ifnum].ifname = ifname;
-		ifnum++;
+		iflist4[ifnum4].sd = sd;
+		iflist4[ifnum4].ifname = ifname;
+
+		ifnum4++;
+	}
+}
+
+void if_init6(char *iface[], int num)
+{
+	int i, sd;
+	char *ifname;
+
+	for (i = 0; i < num; i++) {
+		ifname = iface[i];
+
+		sd = inet6_open(ifname);
+		if (sd < 0)
+			continue;
+
+		iflist6[ifnum6].sd = sd;
+		iflist6[ifnum6].ifname = ifname;
+
+		ifnum6++;
 	}
 }
 
@@ -51,38 +74,90 @@ int if_exit(void)
 	size_t i;
 	int ret = 0;
 
-	for (i = 0; i < ifnum; i++)
-		ret |= inet_close(iflist[i].sd);
+	for (i = 0; i < ifnum4; i++)
+		ret |= inet_close(iflist4[i].sd);
+	for (i = 0; i < ifnum6; i++)
+		ret |= inet6_close(iflist6[i].sd);
 
 	return ret;
 }
 
-void if_send(uint8_t interval)
+void if_send4(uint8_t interval)
 {
 	size_t i;
 
-	for (i = 0; i < ifnum; i++) {
-		if (inet_send(iflist[i].sd, IGMP_MRDISC_ANNOUNCE, interval))
+	for (i = 0; i < ifnum4; i++) {
+		if (inet_send(iflist4[i].sd, IGMP_MRDISC_ANNOUNCE, interval))
 			warn("Failed sending IGMP control message 0x%x on %s",
-			     IGMP_MRDISC_ANNOUNCE, iflist[i].ifname);
+			     IGMP_MRDISC_ANNOUNCE, iflist4[i].ifname);
 	}
+}
+
+void if_send6(uint8_t interval)
+{
+	size_t i;
+
+	for (i = 0; i < ifnum6; i++) {
+		if (inet6_send(iflist6[i].sd, ICMP6_MRDISC_ANNOUNCE, interval))
+			warn("Failed sending ICMPv6 control message 0x%x on %s",
+			     ICMP6_MRDISC_ANNOUNCE, iflist6[i].ifname);
+	}
+}
+
+static void if_poll_init(const ifsock_t sd_arr[], struct pollfd pfd[], int npfd)
+{
+	int i;
+
+	for (i = 0; i < npfd; i++) {
+		pfd[i].fd = sd_arr[i].sd;
+		pfd[i].events = POLLIN | POLLPRI | POLLHUP;
+	}
+}
+
+static int if_recv(int sd, int af, uint8_t interval)
+{
+	switch (af) {
+	case AF_INET:
+		return inet_recv(sd, interval);
+	case AF_INET6:
+		return inet6_recv(sd, interval);
+	default:
+		return -1;
+	}
+}
+
+static int if_poll_recv(int af, const ifsock_t sd_arr[],
+			const struct pollfd pfd[],
+			int npfd, int npoll, uint8_t interval)
+{
+	int i;
+
+	for (i = 0; npoll > 0 && i < npfd; i++) {
+		int   sd     = sd_arr[i].sd;
+		char *ifname = sd_arr[i].ifname;
+
+		if (pfd[i].revents & POLLIN) {
+			if (if_recv(sd, af, interval))
+				warn("Failed reading from interface %s", ifname);
+			npoll--;
+		}
+	}
+
+	return npoll;
 }
 
 void if_poll(uint8_t interval)
 {
 	size_t i;
-	int num = 1;
+	int num;
 	time_t end = time(NULL) + interval;
-	struct pollfd pfd[MAX_NUM_IFACES];
+	struct pollfd pfd[MAX_NUM_IFACES*2];
 
-	for (i = 0; i < ifnum; i++) {
-		pfd[i].fd = iflist[i].sd;
-		pfd[i].events = POLLIN | POLLPRI | POLLHUP;
-	}
+	if_poll_init(iflist4, &pfd[0], ifnum4);
+	if_poll_init(iflist6, &pfd[ifnum4], ifnum6);
 
-again:
 	while (1) {
-		num = poll(pfd, ifnum, (end - time(NULL)) * 1000);
+		num = poll(pfd, ifnum4 + ifnum6, (end - time(NULL)) * 1000);
 		if (num < 0) {
 			if (EINTR == errno)
 				break;
@@ -93,16 +168,8 @@ again:
 		if (num == 0)
 			break;
 
-		for (i = 0; num > 0 && i < ifnum; i++) {
-			int   sd     = iflist[i].sd;
-			char *ifname = iflist[i].ifname;
-
-			if (pfd[i].revents & POLLIN) {
-				if (inet_recv(sd, interval))
-					warn("Failed reading from interface %s", ifname);
-				num--;
-			}
-		}
+		num = if_poll_recv(AF_INET, iflist4, &pfd[0], ifnum4, num, interval);
+		num = if_poll_recv(AF_INET6, iflist6, &pfd[ifnum4], ifnum6, num, interval);
 	}
 }
 

--- a/if.h
+++ b/if.h
@@ -5,8 +5,10 @@ typedef struct {
 	char *ifname;
 } ifsock_t;
 
-void if_init (char *iface[], int num);
+void if_init4 (char *iface[], int num);
+void if_init6 (char *iface[], int num);
 int  if_exit (void);
 
-void if_send (uint8_t interval);
+void if_send4 (uint8_t interval);
+void if_send6 (uint8_t interval);
 void if_poll (uint8_t interval);

--- a/inet.h
+++ b/inet.h
@@ -2,9 +2,17 @@
 #define IGMP_MRDISC_SOLICIT  0x31
 #define IGMP_MRDISC_TERM     0x32
 
-int inet_open  (char *ifname);
-int inet_close (int sd);
+#define ICMP6_MRDISC_ANNOUNCE	151
+#define ICMP6_MRDISC_SOLICIT	152
+#define ICMP6_MRDISC_TERM	153
+
+int inet_open   (char *ifname);
+int inet6_open  (char *ifname);
+int inet_close  (int sd);
+int inet6_close (int sd);
 
 int inet_send  (int sd, uint8_t type, uint8_t interval);
+int inet6_send (int sd, uint8_t type, uint8_t interval);
 int inet_recv  (int sd, uint8_t interval);
+int inet6_recv (int sd, uint8_t interval);
 

--- a/solicit.c
+++ b/solicit.c
@@ -24,14 +24,18 @@
 #include <net/if.h>
 #include <netinet/ip.h>
 #include <netinet/igmp.h>
+#include <netinet/icmp6.h>
 #include <sys/socket.h>
 
 #define MC_ALL_ROUTERS       "224.0.0.2"
+#define MC6_ALL_ROUTERS      "ff02::2"
 #define IGMP_MRDISC_ANNOUNCE 0x30
 #define IGMP_MRDISC_SOLICIT  0x31
 #define IGMP_MRDISC_TERM     0x32
+#define ICMP6_MRDISC_SOLICIT 152
 
 uint16_t in_cksum(uint16_t *p, size_t len);
+void compose_addr6(struct sockaddr_in6 *sin, char *group);
 
 static int open_socket(char *ifname)
 {
@@ -68,6 +72,52 @@ static int open_socket(char *ifname)
 	return sd;
 }
 
+static int open_socket6(char *ifname)
+{
+	int loop = 0;
+	int sd, hops = 1, rc;
+	struct ifreq ifr;
+
+	/**
+	 * hopopt[8]:
+	 * {
+	 *   "nexthdr": 0x00 (updated by kernel), "hdrextlen": 0x00,
+	 *   "rtalert": {
+	 *     "type": 0x05, "length": 0x00, "value": [ 0x00, 0x00 ] },
+	 *   }
+	 *   "PadN": [ 0x01, 0x00 ]
+	 * }
+	 */
+	unsigned char hopopt[8] = { 0x00, 0x00, 0x05, 0x02, 0x00, 0x00, 0x01, 0x00 };
+
+	sd = socket(AF_INET6, SOCK_RAW | SOCK_NONBLOCK | SOCK_CLOEXEC, IPPROTO_ICMPV6);
+	if (sd < 0)
+		err(1, "Cannot open socket");
+
+	memset(&ifr, 0, sizeof(ifr));
+	snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", ifname);
+	if (setsockopt(sd, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr)) < 0) {
+		if (ENODEV == errno) {
+			warnx("Not a valid interface, %s, skipping ...", ifname);
+			close(sd);
+			return -1;
+		}
+
+		err(1, "Cannot bind socket to interface %s", ifname);
+	}
+
+	rc = setsockopt(sd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &hops, sizeof(hops));
+	if (rc < 0)
+		err(1, "Cannot set hop limit");
+
+	rc = setsockopt(sd, IPPROTO_IPV6, IPV6_HOPOPTS, &hopopt, sizeof(hopopt));
+	if (rc < 0)
+		err(1, "Cannot set IPV6 hop-by-hop option");
+
+	return sd;
+
+}
+
 static void compose_addr(struct sockaddr_in *sin, char *group)
 {
 	memset(sin, 0, sizeof(*sin));
@@ -95,18 +145,69 @@ static int send_message(int sd, uint8_t type, uint8_t interval)
 	return 0;
 }
 
-int main(int argc, char *argv[])
+static int send_message6(int sd, uint8_t type, uint8_t interval)
 {
-	int sd;
+	ssize_t num;
+	struct icmp6_hdr icmp6;
+	struct sockaddr_in6 dest;
 
-	if (argc < 2)
-		errx(1, "Usage: %s IFNAME", argv[0]);
+	memset(&icmp6, 0, sizeof(icmp6));
+	icmp6.icmp6_type = type;
+	icmp6.icmp6_code = interval;
+	icmp6.icmp6_cksum = 0; /* updated by kernel */
 
-	sd = open_socket(argv[1]);
-	if (sd < 0)
+	compose_addr6(&dest, MC6_ALL_ROUTERS);
+
+	num = sendto(sd, &icmp6, sizeof(icmp6), 0, (struct sockaddr *)&dest,
+		     sizeof(dest));
+	if (num < 0)
 		return 1;
 
-	return send_message(sd, IGMP_MRDISC_SOLICIT, 0);
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int v4 = 1;
+	int v6 = 1;
+	char *ifname;
+	int sd, ret;
+
+	if (argc < 2)
+		errx(1, "Usage: %s [-4|-6] IFNAME", argv[0]);
+
+	if (!strncmp(argv[1], "-4", strlen("-4"))) {
+		v6 = 0;
+		ifname = argv[2];
+	} else if (!strncmp(argv[1], "-6", strlen("-6"))) {
+		v4 = 0;
+		ifname = argv[2];
+	} else {
+		ifname = argv[1];
+	}
+
+	if ((!v4 || !v6) && argc < 3)
+		errx(1, "Usage: %s [-4|-6] IFNAME", argv[0]);
+
+	if (v4) {
+		sd = open_socket(ifname);
+		if (sd < 0)
+			return 1;
+
+		ret = send_message(sd, IGMP_MRDISC_SOLICIT, 0);
+		close(sd);
+	}
+
+	if (v6) {
+		sd = open_socket6(ifname);
+		if (sd < 0)
+			return 1;
+
+		ret |= send_message6(sd, ICMP6_MRDISC_SOLICIT, 0);
+		close(sd);
+	}
+
+	return ret;
 }
 
 /**


### PR DESCRIPTION
This adds IPv6 support. By default both IPv4 and IPv6 operations are
performed simultaneously. The user can revert to v4-only or v6-only by
using the newly introduced "-4" and "-6" switches.

One noteable difference observed on a Linux 4.19 and 5.1-rc3 kernel was
that contrary to IPv4/IGMP the IPv6/ICMPv6 stack in the kernel
calculates the ICMPv6 checksum on its own and does not need to be
calculated in userspace. (other operating systems were untested)

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>